### PR TITLE
Added detection of ENABLE_INTERFACES environment variable.

### DIFF
--- a/src/masonite/interfaces/Interface.py
+++ b/src/masonite/interfaces/Interface.py
@@ -6,6 +6,7 @@ from .exceptions import InterfaceException
 
 class Interface:
 
+    @staticmethod
     def __is_interfaces_enabled():
         """
         Check if the Interfaces check should be enabled.
@@ -50,7 +51,7 @@ class Interface:
 
             # Get the methods to check from the interface
             for key, method in inspect.getmembers(base_class):
-                if (key.startswith('__') or method.__name__.startswith('__') or key == 'get_parameters'):
+                if key.startswith('__') or method.__name__.startswith('__') or key == 'get_parameters':
                     continue
                 methods_to_check.update({key: [
                     (param_key, param_value)
@@ -65,11 +66,10 @@ class Interface:
                 (param_key, param_value) for param_key, param_value in cls.get_parameters(method)
             ]})
 
-
         cls.__to_check__ = methods_to_check_against  
         # Perform Checks
         for method, values in methods_to_check.items():
-            # Check the existance
+            # Check the existence
             if method not in cls.__dict__ and (method in cls.__to_check__ and method not in inherited_methods):
 
                 raise InterfaceException(

--- a/src/masonite/interfaces/Interface.py
+++ b/src/masonite/interfaces/Interface.py
@@ -37,18 +37,22 @@ class Interface:
 
         methods_to_check = {}
         methods_to_check_against = {}
-        to_check = {}
         inherited_methods = []
 
         for base_class in cls.__bases__:
             if not base_class.__name__.endswith('Interface'):
-                for key, method in inspect.getmembers(base_class):
-                    if not key.startswith('__') and not method.__name__.startswith('__') and key != 'get_parameters':
-                        members = []
-                        for param_key, param_value in cls.get_parameters(method):
-                            members += [(param_key, param_value)]
-                        inherited_methods += [key]
-                        # methods_to_check_against.update({key: members})
+                inherited_methods += [
+                    key for key, method in inspect.getmembers(base_class)
+                    if not key.startswith('__') and not method.__name__.startswith('__')
+                    and key != 'get_parameters'
+                ]
+                # for key, method in inspect.getmembers(base_class):
+                #     if not key.startswith('__') and not method.__name__.startswith('__') and key != 'get_parameters':
+                #         members = []
+                #         for param_key, param_value in cls.get_parameters(method):
+                #             members += [(param_key, param_value)]
+                #         inherited_methods += [key]
+                #         # methods_to_check_against.update({key: members})
                 continue
 
             # Get the methods to check from the interface

--- a/src/masonite/interfaces/Interface.py
+++ b/src/masonite/interfaces/Interface.py
@@ -46,30 +46,24 @@ class Interface:
                     if not key.startswith('__') and not method.__name__.startswith('__')
                     and key != 'get_parameters'
                 ]
-                # for key, method in inspect.getmembers(base_class):
-                #     if not key.startswith('__') and not method.__name__.startswith('__') and key != 'get_parameters':
-                #         members = []
-                #         for param_key, param_value in cls.get_parameters(method):
-                #             members += [(param_key, param_value)]
-                #         inherited_methods += [key]
-                #         # methods_to_check_against.update({key: members})
                 continue
 
             # Get the methods to check from the interface
             for key, method in inspect.getmembers(base_class):
-                if not key.startswith('__') and not method.__name__.startswith('__') and key != 'get_parameters':
-                    members = []
-                    for param_key, param_value in cls.get_parameters(method):
-                        members += [(param_key, param_value)]
-                    methods_to_check.update({key: members})
+                if (key.startswith('__') or method.__name__.startswith('__') or key == 'get_parameters'):
+                    continue
+                methods_to_check.update({key: [
+                    (param_key, param_value)
+                    for param_key, param_value in cls.get_parameters(method)
+                ]})
 
         # Get the methods on the current class
         for key, method in inspect.getmembers(cls):
-            if not key.startswith('__') and key != 'get_parameters':
-                members = []
-                for param_key, param_value in cls.get_parameters(method):
-                    members += [(param_key, param_value)]
-                methods_to_check_against.update({key: members})
+            if key.startswith('__') or key == 'get_parameters':
+                continue
+            methods_to_check_against.update({key: [
+                (param_key, param_value) for param_key, param_value in cls.get_parameters(method)
+            ]})
 
 
         cls.__to_check__ = methods_to_check_against  


### PR DESCRIPTION
Fixes: #2 

This adds detection of the environment variable ENABLE_INTERFACES, for specifically turning the interface checks on and off. When the checks are enabled, it also detects whether this is being used within Masonite, and then makes the checks dependent on DEBUG as well, so that Masonite will, by default, not perform the checks when in production.

Please review this very critically; I'm not one to get offended. Thanks! :)